### PR TITLE
enable amplify datastore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+frontend/src/models

--- a/amplify/README.md
+++ b/amplify/README.md
@@ -50,6 +50,17 @@ amplify publish
 amplify codegen
 ```
 
+You can find the generated files at `frontend/graphql/` and `frontend/API.ts`.
+
+6. generate model code for frontend and datastore
+   Models can also be generated using the Amplify CLI directly. In your terminal, make sure you are in your project/root folder and execute the codegen command
+
+```bash
+amplify codegen models
+```
+
+You can find the generated files at `frontend/models/`.
+
 # Data model and API structure
 
 Petrakip needs logical objects that complex data, such as images or videos, as part of their structure. For example, a Moment type can contain a picture. With AWS AppSync, we can model these as GraphQL types, referred to as complex objects. If any of the mutations have a variable with bucket, key, region, mimeType and localUri fields, the SDK uploads the file to Amazon S3 for you.

--- a/amplify/backend/api/petrakipApi4data/transform.conf.json
+++ b/amplify/backend/api/petrakipApi4data/transform.conf.json
@@ -1,4 +1,10 @@
 {
     "Version": 5,
-    "ElasticsearchWarning": true
+    "ElasticsearchWarning": true,
+    "ResolverConfig": {
+        "project": {
+            "ConflictHandler": "AUTOMERGE",
+            "ConflictDetection": "VERSION"
+        }
+    }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "eslint": "eslint . --ext .ts"
   },
   "dependencies": {
+    "@aws-amplify/datastore": "^3.0.0",
     "@aws-amplify/ui-react": "^1.0.7",
     "@capacitor/core": "2.4.7",
     "@ionic/react": "5.6.5",
@@ -60,19 +61,19 @@
   "devDependencies": {
     "@capacitor/cli": "2.4.7",
     "@ionic/cli": "6.13.1",
-    "eslint": "^7.24.0",
-    "eslint-config-prettier": "^8.2.0",
-    "prettier": "^2.2.1",
     "@testing-library/jest-dom": "5.12.0",
     "@testing-library/react": "11.2.6",
     "@testing-library/user-event": "12.8.3",
     "@types/jest": "26.0.23",
-    "aws-amplify": "^3.3.27",
     "@types/node": "12.20.10",
     "@types/react": "16.14.5",
     "@types/react-dom": "16.9.12",
     "@types/react-router": "5.1.13",
     "@types/react-router-dom": "5.1.7",
+    "aws-amplify": "^3.3.27",
+    "eslint": "^7.24.0",
+    "eslint-config-prettier": "^8.2.0",
+    "prettier": "^2.2.1",
     "react-scripts": "4.0.2",
     "typescript": "4.2.4"
   }

--- a/frontend/src/API.ts
+++ b/frontend/src/API.ts
@@ -6,6 +6,7 @@ export type CreateProfileSettingsInput = {
   id?: string | null
   profileImage?: S3ObjectInput | null
   age?: number | null
+  _version?: number | null
 }
 
 export type S3ObjectInput = {
@@ -51,6 +52,9 @@ export type ProfileSettings = {
   id?: string
   profileImage?: S3Object
   age?: number | null
+  _version?: number
+  _deleted?: boolean | null
+  _lastChangedAt?: number
   createdAt?: string
   updatedAt?: string
   owner?: string | null
@@ -67,10 +71,12 @@ export type UpdateProfileSettingsInput = {
   id: string
   profileImage?: S3ObjectInput | null
   age?: number | null
+  _version?: number | null
 }
 
 export type DeleteProfileSettingsInput = {
   id?: string | null
+  _version?: number | null
 }
 
 export type CreateReflexionInput = {
@@ -89,6 +95,7 @@ export type CreateReflexionInput = {
   sharedUsers?: Array<string | null> | null
   comments?: Array<CommentInput | null> | null
   orientationQuestions?: Array<OrientationQuestionsInput | null> | null
+  _version?: number | null
 }
 
 export enum ContentType {
@@ -190,6 +197,9 @@ export type Reflexion = {
   comments?: Array<Comment | null> | null
   orientationQuestions?: Array<OrientationQuestions | null> | null
   moments?: ModelReflexionMomentConnection
+  _version?: number
+  _deleted?: boolean | null
+  _lastChangedAt?: number
   updatedAt?: string
   owner?: string | null
 }
@@ -209,6 +219,7 @@ export type ModelReflexionMomentConnection = {
   __typename: 'ModelReflexionMomentConnection'
   items?: Array<ReflexionMoment | null> | null
   nextToken?: string | null
+  startedAt?: number | null
 }
 
 export type ReflexionMoment = {
@@ -218,6 +229,9 @@ export type ReflexionMoment = {
   momentID?: string
   reflexion?: Reflexion
   moment?: Moment
+  _version?: number
+  _deleted?: boolean | null
+  _lastChangedAt?: number
   createdAt?: string
   updatedAt?: string
   owner?: string | null
@@ -236,6 +250,9 @@ export type Moment = {
   sharedUsers?: Array<string | null> | null
   comments?: Array<Comment | null> | null
   reflexion?: ModelReflexionMomentConnection
+  _version?: number
+  _deleted?: boolean | null
+  _lastChangedAt?: number
   updatedAt?: string
   owner?: string | null
 }
@@ -256,10 +273,12 @@ export type UpdateReflexionInput = {
   sharedUsers?: Array<string | null> | null
   comments?: Array<CommentInput | null> | null
   orientationQuestions?: Array<OrientationQuestionsInput | null> | null
+  _version?: number | null
 }
 
 export type DeleteReflexionInput = {
   id?: string | null
+  _version?: number | null
 }
 
 export type CreateMomentInput = {
@@ -273,6 +292,7 @@ export type CreateMomentInput = {
   deleted?: boolean | null
   sharedUsers?: Array<string | null> | null
   comments?: Array<CommentInput | null> | null
+  _version?: number | null
 }
 
 export type ModelMomentConditionInput = {
@@ -298,16 +318,19 @@ export type UpdateMomentInput = {
   deleted?: boolean | null
   sharedUsers?: Array<string | null> | null
   comments?: Array<CommentInput | null> | null
+  _version?: number | null
 }
 
 export type DeleteMomentInput = {
   id?: string | null
+  _version?: number | null
 }
 
 export type CreateReflexionMomentInput = {
   id?: string | null
   reflexionID: string
   momentID: string
+  _version?: number | null
 }
 
 export type ModelReflexionMomentConditionInput = {
@@ -338,10 +361,12 @@ export type UpdateReflexionMomentInput = {
   id: string
   reflexionID?: string | null
   momentID?: string | null
+  _version?: number | null
 }
 
 export type DeleteReflexionMomentInput = {
   id?: string | null
+  _version?: number | null
 }
 
 export type ModelProfileSettingsFilterInput = {
@@ -356,6 +381,7 @@ export type ModelProfileSettingsConnection = {
   __typename: 'ModelProfileSettingsConnection'
   items?: Array<ProfileSettings | null> | null
   nextToken?: string | null
+  startedAt?: number | null
 }
 
 export type ModelReflexionFilterInput = {
@@ -380,6 +406,7 @@ export type ModelReflexionConnection = {
   __typename: 'ModelReflexionConnection'
   items?: Array<Reflexion | null> | null
   nextToken?: string | null
+  startedAt?: number | null
 }
 
 export type ModelMomentFilterInput = {
@@ -400,6 +427,16 @@ export type ModelMomentConnection = {
   __typename: 'ModelMomentConnection'
   items?: Array<Moment | null> | null
   nextToken?: string | null
+  startedAt?: number | null
+}
+
+export type ModelReflexionMomentFilterInput = {
+  id?: ModelIDInput | null
+  reflexionID?: ModelIDInput | null
+  momentID?: ModelIDInput | null
+  and?: Array<ModelReflexionMomentFilterInput | null> | null
+  or?: Array<ModelReflexionMomentFilterInput | null> | null
+  not?: ModelReflexionMomentFilterInput | null
 }
 
 export type CreateProfileSettingsMutationVariables = {
@@ -418,6 +455,9 @@ export type CreateProfileSettingsMutation = {
       region: string
     } | null
     age?: number | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     createdAt: string
     updatedAt: string
     owner?: string | null
@@ -440,6 +480,9 @@ export type UpdateProfileSettingsMutation = {
       region: string
     } | null
     age?: number | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     createdAt: string
     updatedAt: string
     owner?: string | null
@@ -462,6 +505,9 @@ export type DeleteProfileSettingsMutation = {
       region: string
     } | null
     age?: number | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     createdAt: string
     updatedAt: string
     owner?: string | null
@@ -506,7 +552,11 @@ export type CreateReflexionMutation = {
     moments?: {
       __typename: 'ModelReflexionMomentConnection'
       nextToken?: string | null
+      startedAt?: number | null
     } | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     updatedAt: string
     owner?: string | null
   } | null
@@ -550,7 +600,11 @@ export type UpdateReflexionMutation = {
     moments?: {
       __typename: 'ModelReflexionMomentConnection'
       nextToken?: string | null
+      startedAt?: number | null
     } | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     updatedAt: string
     owner?: string | null
   } | null
@@ -594,7 +648,11 @@ export type DeleteReflexionMutation = {
     moments?: {
       __typename: 'ModelReflexionMomentConnection'
       nextToken?: string | null
+      startedAt?: number | null
     } | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     updatedAt: string
     owner?: string | null
   } | null
@@ -630,7 +688,11 @@ export type CreateMomentMutation = {
     reflexion?: {
       __typename: 'ModelReflexionMomentConnection'
       nextToken?: string | null
+      startedAt?: number | null
     } | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     updatedAt: string
     owner?: string | null
   } | null
@@ -666,7 +728,11 @@ export type UpdateMomentMutation = {
     reflexion?: {
       __typename: 'ModelReflexionMomentConnection'
       nextToken?: string | null
+      startedAt?: number | null
     } | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     updatedAt: string
     owner?: string | null
   } | null
@@ -702,7 +768,11 @@ export type DeleteMomentMutation = {
     reflexion?: {
       __typename: 'ModelReflexionMomentConnection'
       nextToken?: string | null
+      startedAt?: number | null
     } | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     updatedAt: string
     owner?: string | null
   } | null
@@ -733,6 +803,9 @@ export type CreateReflexionMomentMutation = {
       state?: ReflexionState | null
       deleted?: boolean | null
       sharedUsers?: Array<string | null> | null
+      _version: number
+      _deleted?: boolean | null
+      _lastChangedAt: number
       updatedAt: string
       owner?: string | null
     }
@@ -746,9 +819,15 @@ export type CreateReflexionMomentMutation = {
       tags?: Array<string | null> | null
       deleted?: boolean | null
       sharedUsers?: Array<string | null> | null
+      _version: number
+      _deleted?: boolean | null
+      _lastChangedAt: number
       updatedAt: string
       owner?: string | null
     }
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     createdAt: string
     updatedAt: string
     owner?: string | null
@@ -780,6 +859,9 @@ export type UpdateReflexionMomentMutation = {
       state?: ReflexionState | null
       deleted?: boolean | null
       sharedUsers?: Array<string | null> | null
+      _version: number
+      _deleted?: boolean | null
+      _lastChangedAt: number
       updatedAt: string
       owner?: string | null
     }
@@ -793,9 +875,15 @@ export type UpdateReflexionMomentMutation = {
       tags?: Array<string | null> | null
       deleted?: boolean | null
       sharedUsers?: Array<string | null> | null
+      _version: number
+      _deleted?: boolean | null
+      _lastChangedAt: number
       updatedAt: string
       owner?: string | null
     }
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     createdAt: string
     updatedAt: string
     owner?: string | null
@@ -827,6 +915,9 @@ export type DeleteReflexionMomentMutation = {
       state?: ReflexionState | null
       deleted?: boolean | null
       sharedUsers?: Array<string | null> | null
+      _version: number
+      _deleted?: boolean | null
+      _lastChangedAt: number
       updatedAt: string
       owner?: string | null
     }
@@ -840,12 +931,44 @@ export type DeleteReflexionMomentMutation = {
       tags?: Array<string | null> | null
       deleted?: boolean | null
       sharedUsers?: Array<string | null> | null
+      _version: number
+      _deleted?: boolean | null
+      _lastChangedAt: number
       updatedAt: string
       owner?: string | null
     }
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     createdAt: string
     updatedAt: string
     owner?: string | null
+  } | null
+}
+
+export type SyncProfileSettingsQueryVariables = {
+  filter?: ModelProfileSettingsFilterInput | null
+  limit?: number | null
+  nextToken?: string | null
+  lastSync?: number | null
+}
+
+export type SyncProfileSettingsQuery = {
+  syncProfileSettings?: {
+    __typename: 'ModelProfileSettingsConnection'
+    items?: Array<{
+      __typename: 'ProfileSettings'
+      id: string
+      age?: number | null
+      _version: number
+      _deleted?: boolean | null
+      _lastChangedAt: number
+      createdAt: string
+      updatedAt: string
+      owner?: string | null
+    } | null> | null
+    nextToken?: string | null
+    startedAt?: number | null
   } | null
 }
 
@@ -864,6 +987,9 @@ export type GetProfileSettingsQuery = {
       region: string
     } | null
     age?: number | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     createdAt: string
     updatedAt: string
     owner?: string | null
@@ -883,11 +1009,50 @@ export type ListProfileSettingssQuery = {
       __typename: 'ProfileSettings'
       id: string
       age?: number | null
+      _version: number
+      _deleted?: boolean | null
+      _lastChangedAt: number
       createdAt: string
       updatedAt: string
       owner?: string | null
     } | null> | null
     nextToken?: string | null
+    startedAt?: number | null
+  } | null
+}
+
+export type SyncReflexionsQueryVariables = {
+  filter?: ModelReflexionFilterInput | null
+  limit?: number | null
+  nextToken?: string | null
+  lastSync?: number | null
+}
+
+export type SyncReflexionsQuery = {
+  syncReflexions?: {
+    __typename: 'ModelReflexionConnection'
+    items?: Array<{
+      __typename: 'Reflexion'
+      id: string
+      createdAt?: string | null
+      title?: string | null
+      contentType?: ContentType | null
+      content?: string | null
+      topic?: string | null
+      subTopic?: string | null
+      niveau?: string | null
+      indicators?: Array<string | null> | null
+      state?: ReflexionState | null
+      deleted?: boolean | null
+      sharedUsers?: Array<string | null> | null
+      _version: number
+      _deleted?: boolean | null
+      _lastChangedAt: number
+      updatedAt: string
+      owner?: string | null
+    } | null> | null
+    nextToken?: string | null
+    startedAt?: number | null
   } | null
 }
 
@@ -928,7 +1093,11 @@ export type GetReflexionQuery = {
     moments?: {
       __typename: 'ModelReflexionMomentConnection'
       nextToken?: string | null
+      startedAt?: number | null
     } | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     updatedAt: string
     owner?: string | null
   } | null
@@ -957,10 +1126,45 @@ export type ListReflexionsQuery = {
       state?: ReflexionState | null
       deleted?: boolean | null
       sharedUsers?: Array<string | null> | null
+      _version: number
+      _deleted?: boolean | null
+      _lastChangedAt: number
       updatedAt: string
       owner?: string | null
     } | null> | null
     nextToken?: string | null
+    startedAt?: number | null
+  } | null
+}
+
+export type SyncMomentsQueryVariables = {
+  filter?: ModelMomentFilterInput | null
+  limit?: number | null
+  nextToken?: string | null
+  lastSync?: number | null
+}
+
+export type SyncMomentsQuery = {
+  syncMoments?: {
+    __typename: 'ModelMomentConnection'
+    items?: Array<{
+      __typename: 'Moment'
+      id: string
+      createdAt?: string | null
+      title: string
+      contentType?: ContentType | null
+      content?: string | null
+      tags?: Array<string | null> | null
+      deleted?: boolean | null
+      sharedUsers?: Array<string | null> | null
+      _version: number
+      _deleted?: boolean | null
+      _lastChangedAt: number
+      updatedAt: string
+      owner?: string | null
+    } | null> | null
+    nextToken?: string | null
+    startedAt?: number | null
   } | null
 }
 
@@ -993,7 +1197,11 @@ export type GetMomentQuery = {
     reflexion?: {
       __typename: 'ModelReflexionMomentConnection'
       nextToken?: string | null
+      startedAt?: number | null
     } | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     updatedAt: string
     owner?: string | null
   } | null
@@ -1018,10 +1226,41 @@ export type ListMomentsQuery = {
       tags?: Array<string | null> | null
       deleted?: boolean | null
       sharedUsers?: Array<string | null> | null
+      _version: number
+      _deleted?: boolean | null
+      _lastChangedAt: number
       updatedAt: string
       owner?: string | null
     } | null> | null
     nextToken?: string | null
+    startedAt?: number | null
+  } | null
+}
+
+export type SyncReflexionMomentsQueryVariables = {
+  filter?: ModelReflexionMomentFilterInput | null
+  limit?: number | null
+  nextToken?: string | null
+  lastSync?: number | null
+}
+
+export type SyncReflexionMomentsQuery = {
+  syncReflexionMoments?: {
+    __typename: 'ModelReflexionMomentConnection'
+    items?: Array<{
+      __typename: 'ReflexionMoment'
+      id: string
+      reflexionID: string
+      momentID: string
+      _version: number
+      _deleted?: boolean | null
+      _lastChangedAt: number
+      createdAt: string
+      updatedAt: string
+      owner?: string | null
+    } | null> | null
+    nextToken?: string | null
+    startedAt?: number | null
   } | null
 }
 
@@ -1040,6 +1279,9 @@ export type OnCreateProfileSettingsSubscription = {
       region: string
     } | null
     age?: number | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     createdAt: string
     updatedAt: string
     owner?: string | null
@@ -1061,6 +1303,9 @@ export type OnUpdateProfileSettingsSubscription = {
       region: string
     } | null
     age?: number | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     createdAt: string
     updatedAt: string
     owner?: string | null
@@ -1082,6 +1327,9 @@ export type OnDeleteProfileSettingsSubscription = {
       region: string
     } | null
     age?: number | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     createdAt: string
     updatedAt: string
     owner?: string | null
@@ -1126,7 +1374,11 @@ export type OnCreateReflexionSubscription = {
     moments?: {
       __typename: 'ModelReflexionMomentConnection'
       nextToken?: string | null
+      startedAt?: number | null
     } | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     updatedAt: string
     owner?: string | null
   } | null
@@ -1170,7 +1422,11 @@ export type OnUpdateReflexionSubscription = {
     moments?: {
       __typename: 'ModelReflexionMomentConnection'
       nextToken?: string | null
+      startedAt?: number | null
     } | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     updatedAt: string
     owner?: string | null
   } | null
@@ -1214,7 +1470,11 @@ export type OnDeleteReflexionSubscription = {
     moments?: {
       __typename: 'ModelReflexionMomentConnection'
       nextToken?: string | null
+      startedAt?: number | null
     } | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     updatedAt: string
     owner?: string | null
   } | null
@@ -1250,7 +1510,11 @@ export type OnCreateMomentSubscription = {
     reflexion?: {
       __typename: 'ModelReflexionMomentConnection'
       nextToken?: string | null
+      startedAt?: number | null
     } | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     updatedAt: string
     owner?: string | null
   } | null
@@ -1286,7 +1550,11 @@ export type OnUpdateMomentSubscription = {
     reflexion?: {
       __typename: 'ModelReflexionMomentConnection'
       nextToken?: string | null
+      startedAt?: number | null
     } | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     updatedAt: string
     owner?: string | null
   } | null
@@ -1322,7 +1590,11 @@ export type OnDeleteMomentSubscription = {
     reflexion?: {
       __typename: 'ModelReflexionMomentConnection'
       nextToken?: string | null
+      startedAt?: number | null
     } | null
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     updatedAt: string
     owner?: string | null
   } | null
@@ -1352,6 +1624,9 @@ export type OnCreateReflexionMomentSubscription = {
       state?: ReflexionState | null
       deleted?: boolean | null
       sharedUsers?: Array<string | null> | null
+      _version: number
+      _deleted?: boolean | null
+      _lastChangedAt: number
       updatedAt: string
       owner?: string | null
     }
@@ -1365,9 +1640,15 @@ export type OnCreateReflexionMomentSubscription = {
       tags?: Array<string | null> | null
       deleted?: boolean | null
       sharedUsers?: Array<string | null> | null
+      _version: number
+      _deleted?: boolean | null
+      _lastChangedAt: number
       updatedAt: string
       owner?: string | null
     }
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     createdAt: string
     updatedAt: string
     owner?: string | null
@@ -1398,6 +1679,9 @@ export type OnUpdateReflexionMomentSubscription = {
       state?: ReflexionState | null
       deleted?: boolean | null
       sharedUsers?: Array<string | null> | null
+      _version: number
+      _deleted?: boolean | null
+      _lastChangedAt: number
       updatedAt: string
       owner?: string | null
     }
@@ -1411,9 +1695,15 @@ export type OnUpdateReflexionMomentSubscription = {
       tags?: Array<string | null> | null
       deleted?: boolean | null
       sharedUsers?: Array<string | null> | null
+      _version: number
+      _deleted?: boolean | null
+      _lastChangedAt: number
       updatedAt: string
       owner?: string | null
     }
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     createdAt: string
     updatedAt: string
     owner?: string | null
@@ -1444,6 +1734,9 @@ export type OnDeleteReflexionMomentSubscription = {
       state?: ReflexionState | null
       deleted?: boolean | null
       sharedUsers?: Array<string | null> | null
+      _version: number
+      _deleted?: boolean | null
+      _lastChangedAt: number
       updatedAt: string
       owner?: string | null
     }
@@ -1457,9 +1750,15 @@ export type OnDeleteReflexionMomentSubscription = {
       tags?: Array<string | null> | null
       deleted?: boolean | null
       sharedUsers?: Array<string | null> | null
+      _version: number
+      _deleted?: boolean | null
+      _lastChangedAt: number
       updatedAt: string
       owner?: string | null
     }
+    _version: number
+    _deleted?: boolean | null
+    _lastChangedAt: number
     createdAt: string
     updatedAt: string
     owner?: string | null

--- a/frontend/src/graphql/mutations.ts
+++ b/frontend/src/graphql/mutations.ts
@@ -15,6 +15,9 @@ export const createProfileSettings = /* GraphQL */ `
         region
       }
       age
+      _version
+      _deleted
+      _lastChangedAt
       createdAt
       updatedAt
       owner
@@ -34,6 +37,9 @@ export const updateProfileSettings = /* GraphQL */ `
         region
       }
       age
+      _version
+      _deleted
+      _lastChangedAt
       createdAt
       updatedAt
       owner
@@ -53,6 +59,9 @@ export const deleteProfileSettings = /* GraphQL */ `
         region
       }
       age
+      _version
+      _deleted
+      _lastChangedAt
       createdAt
       updatedAt
       owner
@@ -91,7 +100,11 @@ export const createReflexion = /* GraphQL */ `
       }
       moments {
         nextToken
+        startedAt
       }
+      _version
+      _deleted
+      _lastChangedAt
       updatedAt
       owner
     }
@@ -129,7 +142,11 @@ export const updateReflexion = /* GraphQL */ `
       }
       moments {
         nextToken
+        startedAt
       }
+      _version
+      _deleted
+      _lastChangedAt
       updatedAt
       owner
     }
@@ -167,7 +184,11 @@ export const deleteReflexion = /* GraphQL */ `
       }
       moments {
         nextToken
+        startedAt
       }
+      _version
+      _deleted
+      _lastChangedAt
       updatedAt
       owner
     }
@@ -198,7 +219,11 @@ export const createMoment = /* GraphQL */ `
       }
       reflexion {
         nextToken
+        startedAt
       }
+      _version
+      _deleted
+      _lastChangedAt
       updatedAt
       owner
     }
@@ -229,7 +254,11 @@ export const updateMoment = /* GraphQL */ `
       }
       reflexion {
         nextToken
+        startedAt
       }
+      _version
+      _deleted
+      _lastChangedAt
       updatedAt
       owner
     }
@@ -260,7 +289,11 @@ export const deleteMoment = /* GraphQL */ `
       }
       reflexion {
         nextToken
+        startedAt
       }
+      _version
+      _deleted
+      _lastChangedAt
       updatedAt
       owner
     }
@@ -288,6 +321,9 @@ export const createReflexionMoment = /* GraphQL */ `
         state
         deleted
         sharedUsers
+        _version
+        _deleted
+        _lastChangedAt
         updatedAt
         owner
       }
@@ -300,9 +336,15 @@ export const createReflexionMoment = /* GraphQL */ `
         tags
         deleted
         sharedUsers
+        _version
+        _deleted
+        _lastChangedAt
         updatedAt
         owner
       }
+      _version
+      _deleted
+      _lastChangedAt
       createdAt
       updatedAt
       owner
@@ -331,6 +373,9 @@ export const updateReflexionMoment = /* GraphQL */ `
         state
         deleted
         sharedUsers
+        _version
+        _deleted
+        _lastChangedAt
         updatedAt
         owner
       }
@@ -343,9 +388,15 @@ export const updateReflexionMoment = /* GraphQL */ `
         tags
         deleted
         sharedUsers
+        _version
+        _deleted
+        _lastChangedAt
         updatedAt
         owner
       }
+      _version
+      _deleted
+      _lastChangedAt
       createdAt
       updatedAt
       owner
@@ -374,6 +425,9 @@ export const deleteReflexionMoment = /* GraphQL */ `
         state
         deleted
         sharedUsers
+        _version
+        _deleted
+        _lastChangedAt
         updatedAt
         owner
       }
@@ -386,9 +440,15 @@ export const deleteReflexionMoment = /* GraphQL */ `
         tags
         deleted
         sharedUsers
+        _version
+        _deleted
+        _lastChangedAt
         updatedAt
         owner
       }
+      _version
+      _deleted
+      _lastChangedAt
       createdAt
       updatedAt
       owner

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -2,6 +2,34 @@
 /* eslint-disable */
 // this is an auto generated file. This will be overwritten
 
+export const syncProfileSettings = /* GraphQL */ `
+  query SyncProfileSettings(
+    $filter: ModelProfileSettingsFilterInput
+    $limit: Int
+    $nextToken: String
+    $lastSync: AWSTimestamp
+  ) {
+    syncProfileSettings(
+      filter: $filter
+      limit: $limit
+      nextToken: $nextToken
+      lastSync: $lastSync
+    ) {
+      items {
+        id
+        age
+        _version
+        _deleted
+        _lastChangedAt
+        createdAt
+        updatedAt
+        owner
+      }
+      nextToken
+      startedAt
+    }
+  }
+`
 export const getProfileSettings = /* GraphQL */ `
   query GetProfileSettings($id: ID!) {
     getProfileSettings(id: $id) {
@@ -12,6 +40,9 @@ export const getProfileSettings = /* GraphQL */ `
         region
       }
       age
+      _version
+      _deleted
+      _lastChangedAt
       createdAt
       updatedAt
       owner
@@ -32,11 +63,52 @@ export const listProfileSettingss = /* GraphQL */ `
       items {
         id
         age
+        _version
+        _deleted
+        _lastChangedAt
         createdAt
         updatedAt
         owner
       }
       nextToken
+      startedAt
+    }
+  }
+`
+export const syncReflexions = /* GraphQL */ `
+  query SyncReflexions(
+    $filter: ModelReflexionFilterInput
+    $limit: Int
+    $nextToken: String
+    $lastSync: AWSTimestamp
+  ) {
+    syncReflexions(
+      filter: $filter
+      limit: $limit
+      nextToken: $nextToken
+      lastSync: $lastSync
+    ) {
+      items {
+        id
+        createdAt
+        title
+        contentType
+        content
+        topic
+        subTopic
+        niveau
+        indicators
+        state
+        deleted
+        sharedUsers
+        _version
+        _deleted
+        _lastChangedAt
+        updatedAt
+        owner
+      }
+      nextToken
+      startedAt
     }
   }
 `
@@ -69,7 +141,11 @@ export const getReflexion = /* GraphQL */ `
       }
       moments {
         nextToken
+        startedAt
       }
+      _version
+      _deleted
+      _lastChangedAt
       updatedAt
       owner
     }
@@ -95,10 +171,47 @@ export const listReflexions = /* GraphQL */ `
         state
         deleted
         sharedUsers
+        _version
+        _deleted
+        _lastChangedAt
         updatedAt
         owner
       }
       nextToken
+      startedAt
+    }
+  }
+`
+export const syncMoments = /* GraphQL */ `
+  query SyncMoments(
+    $filter: ModelMomentFilterInput
+    $limit: Int
+    $nextToken: String
+    $lastSync: AWSTimestamp
+  ) {
+    syncMoments(
+      filter: $filter
+      limit: $limit
+      nextToken: $nextToken
+      lastSync: $lastSync
+    ) {
+      items {
+        id
+        createdAt
+        title
+        contentType
+        content
+        tags
+        deleted
+        sharedUsers
+        _version
+        _deleted
+        _lastChangedAt
+        updatedAt
+        owner
+      }
+      nextToken
+      startedAt
     }
   }
 `
@@ -124,7 +237,11 @@ export const getMoment = /* GraphQL */ `
       }
       reflexion {
         nextToken
+        startedAt
       }
+      _version
+      _deleted
+      _lastChangedAt
       updatedAt
       owner
     }
@@ -146,10 +263,43 @@ export const listMoments = /* GraphQL */ `
         tags
         deleted
         sharedUsers
+        _version
+        _deleted
+        _lastChangedAt
         updatedAt
         owner
       }
       nextToken
+      startedAt
+    }
+  }
+`
+export const syncReflexionMoments = /* GraphQL */ `
+  query SyncReflexionMoments(
+    $filter: ModelReflexionMomentFilterInput
+    $limit: Int
+    $nextToken: String
+    $lastSync: AWSTimestamp
+  ) {
+    syncReflexionMoments(
+      filter: $filter
+      limit: $limit
+      nextToken: $nextToken
+      lastSync: $lastSync
+    ) {
+      items {
+        id
+        reflexionID
+        momentID
+        _version
+        _deleted
+        _lastChangedAt
+        createdAt
+        updatedAt
+        owner
+      }
+      nextToken
+      startedAt
     }
   }
 `

--- a/frontend/src/graphql/subscriptions.ts
+++ b/frontend/src/graphql/subscriptions.ts
@@ -12,6 +12,9 @@ export const onCreateProfileSettings = /* GraphQL */ `
         region
       }
       age
+      _version
+      _deleted
+      _lastChangedAt
       createdAt
       updatedAt
       owner
@@ -28,6 +31,9 @@ export const onUpdateProfileSettings = /* GraphQL */ `
         region
       }
       age
+      _version
+      _deleted
+      _lastChangedAt
       createdAt
       updatedAt
       owner
@@ -44,6 +50,9 @@ export const onDeleteProfileSettings = /* GraphQL */ `
         region
       }
       age
+      _version
+      _deleted
+      _lastChangedAt
       createdAt
       updatedAt
       owner
@@ -79,7 +88,11 @@ export const onCreateReflexion = /* GraphQL */ `
       }
       moments {
         nextToken
+        startedAt
       }
+      _version
+      _deleted
+      _lastChangedAt
       updatedAt
       owner
     }
@@ -114,7 +127,11 @@ export const onUpdateReflexion = /* GraphQL */ `
       }
       moments {
         nextToken
+        startedAt
       }
+      _version
+      _deleted
+      _lastChangedAt
       updatedAt
       owner
     }
@@ -149,7 +166,11 @@ export const onDeleteReflexion = /* GraphQL */ `
       }
       moments {
         nextToken
+        startedAt
       }
+      _version
+      _deleted
+      _lastChangedAt
       updatedAt
       owner
     }
@@ -177,7 +198,11 @@ export const onCreateMoment = /* GraphQL */ `
       }
       reflexion {
         nextToken
+        startedAt
       }
+      _version
+      _deleted
+      _lastChangedAt
       updatedAt
       owner
     }
@@ -205,7 +230,11 @@ export const onUpdateMoment = /* GraphQL */ `
       }
       reflexion {
         nextToken
+        startedAt
       }
+      _version
+      _deleted
+      _lastChangedAt
       updatedAt
       owner
     }
@@ -233,7 +262,11 @@ export const onDeleteMoment = /* GraphQL */ `
       }
       reflexion {
         nextToken
+        startedAt
       }
+      _version
+      _deleted
+      _lastChangedAt
       updatedAt
       owner
     }
@@ -258,6 +291,9 @@ export const onCreateReflexionMoment = /* GraphQL */ `
         state
         deleted
         sharedUsers
+        _version
+        _deleted
+        _lastChangedAt
         updatedAt
         owner
       }
@@ -270,9 +306,15 @@ export const onCreateReflexionMoment = /* GraphQL */ `
         tags
         deleted
         sharedUsers
+        _version
+        _deleted
+        _lastChangedAt
         updatedAt
         owner
       }
+      _version
+      _deleted
+      _lastChangedAt
       createdAt
       updatedAt
       owner
@@ -298,6 +340,9 @@ export const onUpdateReflexionMoment = /* GraphQL */ `
         state
         deleted
         sharedUsers
+        _version
+        _deleted
+        _lastChangedAt
         updatedAt
         owner
       }
@@ -310,9 +355,15 @@ export const onUpdateReflexionMoment = /* GraphQL */ `
         tags
         deleted
         sharedUsers
+        _version
+        _deleted
+        _lastChangedAt
         updatedAt
         owner
       }
+      _version
+      _deleted
+      _lastChangedAt
       createdAt
       updatedAt
       owner
@@ -338,6 +389,9 @@ export const onDeleteReflexionMoment = /* GraphQL */ `
         state
         deleted
         sharedUsers
+        _version
+        _deleted
+        _lastChangedAt
         updatedAt
         owner
       }
@@ -350,9 +404,15 @@ export const onDeleteReflexionMoment = /* GraphQL */ `
         tags
         deleted
         sharedUsers
+        _version
+        _deleted
+        _lastChangedAt
         updatedAt
         owner
       }
+      _version
+      _deleted
+      _lastChangedAt
       createdAt
       updatedAt
       owner

--- a/frontend/src/models/index.d.ts
+++ b/frontend/src/models/index.d.ts
@@ -1,0 +1,105 @@
+import {
+  ModelInit,
+  MutableModel,
+  PersistentModelConstructor,
+} from '@aws-amplify/datastore'
+
+export enum ContentType {
+  IMAGE = 'image',
+  VIDEO = 'video',
+  TEXT = 'text',
+  AUDIO = 'audio',
+}
+
+export enum ReflexionState {
+  STARTED = 'started',
+  AWAITING_FOLLOW_UP_QUESTIONS = 'awaitingFollowUpQuestions',
+  COMPLETED = 'completed',
+}
+
+export declare class S3Object {
+  readonly bucket: string
+  readonly key: string
+  readonly region: string
+  constructor(init: ModelInit<S3Object>)
+}
+
+export declare class Comment {
+  readonly createdAt: string
+  readonly content: string
+  constructor(init: ModelInit<Comment>)
+}
+
+export declare class OrientationQuestions {
+  readonly question: string
+  constructor(init: ModelInit<OrientationQuestions>)
+}
+
+export declare class ProfileSettings {
+  readonly id: string
+  readonly profileImage?: S3Object
+  readonly age?: number
+  constructor(init: ModelInit<ProfileSettings>)
+  static copyOf(
+    source: ProfileSettings,
+    mutator: (
+      draft: MutableModel<ProfileSettings>,
+    ) => MutableModel<ProfileSettings> | void,
+  ): ProfileSettings
+}
+
+export declare class Reflexion {
+  readonly id: string
+  readonly createdAt?: string
+  readonly title?: string
+  readonly contentType?: ContentType | keyof typeof ContentType
+  readonly content?: string
+  readonly asset?: S3Object
+  readonly topic?: string
+  readonly subTopic?: string
+  readonly niveau?: string
+  readonly indicators?: (string | null)[]
+  readonly state?: ReflexionState | keyof typeof ReflexionState
+  readonly deleted?: boolean
+  readonly sharedUsers?: (string | null)[]
+  readonly comments?: (Comment | null)[]
+  readonly orientationQuestions?: (OrientationQuestions | null)[]
+  readonly moments?: (ReflexionMoment | null)[]
+  constructor(init: ModelInit<Reflexion>)
+  static copyOf(
+    source: Reflexion,
+    mutator: (draft: MutableModel<Reflexion>) => MutableModel<Reflexion> | void,
+  ): Reflexion
+}
+
+export declare class ReflexionMoment {
+  readonly id: string
+  readonly reflexion: Reflexion
+  readonly moment: Moment
+  constructor(init: ModelInit<ReflexionMoment>)
+  static copyOf(
+    source: ReflexionMoment,
+    mutator: (
+      draft: MutableModel<ReflexionMoment>,
+    ) => MutableModel<ReflexionMoment> | void,
+  ): ReflexionMoment
+}
+
+export declare class Moment {
+  readonly id: string
+  readonly createdAt?: string
+  readonly title: string
+  readonly contentType?: ContentType | keyof typeof ContentType
+  readonly content?: string
+  readonly asset?: S3Object
+  readonly tags?: (string | null)[]
+  readonly deleted?: boolean
+  readonly sharedUsers?: (string | null)[]
+  readonly comments?: (Comment | null)[]
+  readonly reflexion?: (ReflexionMoment | null)[]
+  constructor(init: ModelInit<Moment>)
+  static copyOf(
+    source: Moment,
+    mutator: (draft: MutableModel<Moment>) => MutableModel<Moment> | void,
+  ): Moment
+}

--- a/frontend/src/models/index.js
+++ b/frontend/src/models/index.js
@@ -1,0 +1,30 @@
+// @ts-check
+import { initSchema } from '@aws-amplify/datastore';
+import { schema } from './schema';
+
+const ContentType = {
+  "IMAGE": "image",
+  "VIDEO": "video",
+  "TEXT": "text",
+  "AUDIO": "audio"
+};
+
+const ReflexionState = {
+  "STARTED": "started",
+  "AWAITING_FOLLOW_UP_QUESTIONS": "awaitingFollowUpQuestions",
+  "COMPLETED": "completed"
+};
+
+const { ProfileSettings, Reflexion, ReflexionMoment, Moment, S3Object, Comment, OrientationQuestions } = initSchema(schema);
+
+export {
+  ProfileSettings,
+  Reflexion,
+  ReflexionMoment,
+  Moment,
+  ContentType,
+  ReflexionState,
+  S3Object,
+  Comment,
+  OrientationQuestions
+};

--- a/frontend/src/models/schema.d.ts
+++ b/frontend/src/models/schema.d.ts
@@ -1,0 +1,3 @@
+import { Schema } from '@aws-amplify/datastore'
+
+export declare const schema: Schema

--- a/frontend/src/models/schema.js
+++ b/frontend/src/models/schema.js
@@ -1,0 +1,533 @@
+export const schema = {
+    "models": {
+        "ProfileSettings": {
+            "name": "ProfileSettings",
+            "fields": {
+                "id": {
+                    "name": "id",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "profileImage": {
+                    "name": "profileImage",
+                    "isArray": false,
+                    "type": {
+                        "nonModel": "S3Object"
+                    },
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "age": {
+                    "name": "age",
+                    "isArray": false,
+                    "type": "Int",
+                    "isRequired": false,
+                    "attributes": []
+                }
+            },
+            "syncable": true,
+            "pluralName": "ProfileSettings",
+            "attributes": [
+                {
+                    "type": "model",
+                    "properties": {}
+                },
+                {
+                    "type": "auth",
+                    "properties": {
+                        "rules": [
+                            {
+                                "provider": "userPools",
+                                "ownerField": "owner",
+                                "allow": "owner",
+                                "identityClaim": "cognito:username",
+                                "operations": [
+                                    "create",
+                                    "update",
+                                    "delete",
+                                    "read"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "Reflexion": {
+            "name": "Reflexion",
+            "fields": {
+                "id": {
+                    "name": "id",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "title": {
+                    "name": "title",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "contentType": {
+                    "name": "contentType",
+                    "isArray": false,
+                    "type": {
+                        "enum": "ContentType"
+                    },
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "content": {
+                    "name": "content",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "asset": {
+                    "name": "asset",
+                    "isArray": false,
+                    "type": {
+                        "nonModel": "S3Object"
+                    },
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "topic": {
+                    "name": "topic",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "subTopic": {
+                    "name": "subTopic",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "niveau": {
+                    "name": "niveau",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "indicators": {
+                    "name": "indicators",
+                    "isArray": true,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true
+                },
+                "state": {
+                    "name": "state",
+                    "isArray": false,
+                    "type": {
+                        "enum": "ReflexionState"
+                    },
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "deleted": {
+                    "name": "deleted",
+                    "isArray": false,
+                    "type": "Boolean",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "sharedUsers": {
+                    "name": "sharedUsers",
+                    "isArray": true,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true
+                },
+                "comments": {
+                    "name": "comments",
+                    "isArray": true,
+                    "type": {
+                        "nonModel": "Comment"
+                    },
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true
+                },
+                "orientationQuestions": {
+                    "name": "orientationQuestions",
+                    "isArray": true,
+                    "type": {
+                        "nonModel": "OrientationQuestions"
+                    },
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true
+                },
+                "moments": {
+                    "name": "moments",
+                    "isArray": true,
+                    "type": {
+                        "model": "ReflexionMoment"
+                    },
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true,
+                    "association": {
+                        "connectionType": "HAS_MANY",
+                        "associatedWith": "reflexion"
+                    }
+                }
+            },
+            "syncable": true,
+            "pluralName": "Reflexions",
+            "attributes": [
+                {
+                    "type": "model",
+                    "properties": {}
+                },
+                {
+                    "type": "auth",
+                    "properties": {
+                        "rules": [
+                            {
+                                "provider": "userPools",
+                                "ownerField": "owner",
+                                "allow": "owner",
+                                "identityClaim": "cognito:username",
+                                "operations": [
+                                    "create",
+                                    "update",
+                                    "delete",
+                                    "read"
+                                ]
+                            },
+                            {
+                                "provider": "userPools",
+                                "ownerField": "sharedUsers",
+                                "allow": "owner",
+                                "operations": [
+                                    "read"
+                                ],
+                                "identityClaim": "cognito:username"
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "ReflexionMoment": {
+            "name": "ReflexionMoment",
+            "fields": {
+                "id": {
+                    "name": "id",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "reflexion": {
+                    "name": "reflexion",
+                    "isArray": false,
+                    "type": {
+                        "model": "Reflexion"
+                    },
+                    "isRequired": true,
+                    "attributes": [],
+                    "association": {
+                        "connectionType": "BELONGS_TO",
+                        "targetName": "reflexionID"
+                    }
+                },
+                "moment": {
+                    "name": "moment",
+                    "isArray": false,
+                    "type": {
+                        "model": "Moment"
+                    },
+                    "isRequired": true,
+                    "attributes": [],
+                    "association": {
+                        "connectionType": "BELONGS_TO",
+                        "targetName": "momentID"
+                    }
+                }
+            },
+            "syncable": true,
+            "pluralName": "ReflexionMoments",
+            "attributes": [
+                {
+                    "type": "model",
+                    "properties": {
+                        "queries": null
+                    }
+                },
+                {
+                    "type": "key",
+                    "properties": {
+                        "name": "byReflexion",
+                        "fields": [
+                            "reflexionID",
+                            "momentID"
+                        ]
+                    }
+                },
+                {
+                    "type": "key",
+                    "properties": {
+                        "name": "byMoment",
+                        "fields": [
+                            "momentID",
+                            "reflexionID"
+                        ]
+                    }
+                },
+                {
+                    "type": "auth",
+                    "properties": {
+                        "rules": [
+                            {
+                                "provider": "userPools",
+                                "ownerField": "owner",
+                                "allow": "owner",
+                                "identityClaim": "cognito:username",
+                                "operations": [
+                                    "create",
+                                    "update",
+                                    "delete",
+                                    "read"
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "Moment": {
+            "name": "Moment",
+            "fields": {
+                "id": {
+                    "name": "id",
+                    "isArray": false,
+                    "type": "ID",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "createdAt": {
+                    "name": "createdAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "title": {
+                    "name": "title",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "contentType": {
+                    "name": "contentType",
+                    "isArray": false,
+                    "type": {
+                        "enum": "ContentType"
+                    },
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "content": {
+                    "name": "content",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "asset": {
+                    "name": "asset",
+                    "isArray": false,
+                    "type": {
+                        "nonModel": "S3Object"
+                    },
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "tags": {
+                    "name": "tags",
+                    "isArray": true,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true
+                },
+                "deleted": {
+                    "name": "deleted",
+                    "isArray": false,
+                    "type": "Boolean",
+                    "isRequired": false,
+                    "attributes": []
+                },
+                "sharedUsers": {
+                    "name": "sharedUsers",
+                    "isArray": true,
+                    "type": "String",
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true
+                },
+                "comments": {
+                    "name": "comments",
+                    "isArray": true,
+                    "type": {
+                        "nonModel": "Comment"
+                    },
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true
+                },
+                "reflexion": {
+                    "name": "reflexion",
+                    "isArray": true,
+                    "type": {
+                        "model": "ReflexionMoment"
+                    },
+                    "isRequired": false,
+                    "attributes": [],
+                    "isArrayNullable": true,
+                    "association": {
+                        "connectionType": "HAS_MANY",
+                        "associatedWith": "moment"
+                    }
+                }
+            },
+            "syncable": true,
+            "pluralName": "Moments",
+            "attributes": [
+                {
+                    "type": "model",
+                    "properties": {}
+                },
+                {
+                    "type": "auth",
+                    "properties": {
+                        "rules": [
+                            {
+                                "provider": "userPools",
+                                "ownerField": "owner",
+                                "allow": "owner",
+                                "identityClaim": "cognito:username",
+                                "operations": [
+                                    "create",
+                                    "update",
+                                    "delete",
+                                    "read"
+                                ]
+                            },
+                            {
+                                "provider": "userPools",
+                                "ownerField": "sharedUsers",
+                                "allow": "owner",
+                                "operations": [
+                                    "read"
+                                ],
+                                "identityClaim": "cognito:username"
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    },
+    "enums": {
+        "ContentType": {
+            "name": "ContentType",
+            "values": [
+                "image",
+                "video",
+                "text",
+                "audio"
+            ]
+        },
+        "ReflexionState": {
+            "name": "ReflexionState",
+            "values": [
+                "started",
+                "awaitingFollowUpQuestions",
+                "completed"
+            ]
+        }
+    },
+    "nonModels": {
+        "S3Object": {
+            "name": "S3Object",
+            "fields": {
+                "bucket": {
+                    "name": "bucket",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "key": {
+                    "name": "key",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "region": {
+                    "name": "region",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": true,
+                    "attributes": []
+                }
+            }
+        },
+        "Comment": {
+            "name": "Comment",
+            "fields": {
+                "createdAt": {
+                    "name": "createdAt",
+                    "isArray": false,
+                    "type": "AWSDateTime",
+                    "isRequired": true,
+                    "attributes": []
+                },
+                "content": {
+                    "name": "content",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": true,
+                    "attributes": []
+                }
+            }
+        },
+        "OrientationQuestions": {
+            "name": "OrientationQuestions",
+            "fields": {
+                "question": {
+                    "name": "question",
+                    "isArray": false,
+                    "type": "String",
+                    "isRequired": true,
+                    "attributes": []
+                }
+            }
+        }
+    },
+    "version": "ccacf35c68d65bb0457b560389abdc66"
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -31,12 +31,34 @@
     uuid "^3.2.1"
     zen-observable-ts "0.8.19"
 
+"@aws-amplify/api-graphql@1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/api-graphql/-/api-graphql-1.3.1.tgz#17dcb176f350f02bd56b8e675d38614c1104f5b1"
+  integrity sha512-2lRyvG4Z2Q7ikc7zLDdKBPtUTVJ/V5H020CHrqdG0loMaksVoz3XyGpkyJltjJaL2tuAO1Ha/RrlZLWP/0KuRw==
+  dependencies:
+    "@aws-amplify/api-rest" "1.2.32"
+    "@aws-amplify/auth" "3.4.32"
+    "@aws-amplify/cache" "4.0.0"
+    "@aws-amplify/core" "4.0.0"
+    "@aws-amplify/pubsub" "3.3.1"
+    graphql "14.0.0"
+    uuid "^3.2.1"
+    zen-observable-ts "0.8.19"
+
 "@aws-amplify/api-rest@1.2.30":
   version "1.2.30"
   resolved "https://registry.yarnpkg.com/@aws-amplify/api-rest/-/api-rest-1.2.30.tgz#ab2cf0ca0aeb960abbfcc0a4a9d0d5c119b78eda"
   integrity sha512-mvcQ+u+j9dv1v2rSMZ2I31sSimIAi45UXmOTAUAjHEac/u8OYlUyLKG2DcTs1QmFKxNL0CHWqi060amjIIhfYg==
   dependencies:
     "@aws-amplify/core" "3.8.22"
+    axios "0.21.1"
+
+"@aws-amplify/api-rest@1.2.32":
+  version "1.2.32"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/api-rest/-/api-rest-1.2.32.tgz#0af2aec08666eba1fa7715c3e93abad1dbbd851a"
+  integrity sha512-JmTYzv4Zz1r4wJCehiMI5h0MZCal4ukMKRyesQvlaOBK7NQRDVsf1ij3tGBjNys896j+k6b6iQFvBm5ZpW+y1Q==
+  dependencies:
+    "@aws-amplify/core" "4.0.0"
     axios "0.21.1"
 
 "@aws-amplify/api@3.2.30":
@@ -46,6 +68,14 @@
   dependencies:
     "@aws-amplify/api-graphql" "1.2.30"
     "@aws-amplify/api-rest" "1.2.30"
+
+"@aws-amplify/api@3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/api/-/api-3.3.1.tgz#3b99d5e1092f4c18eb05f7a0d13efa60ddef6b26"
+  integrity sha512-0iItd5ioY3tQ+qtgOkGA07bT9Dt4qRSuisRsgTJz8ht4R+snr0tK3x9N7x0UbUkNkgJ7B3sLbotZZVSAcaDkEA==
+  dependencies:
+    "@aws-amplify/api-graphql" "1.3.1"
+    "@aws-amplify/api-rest" "1.2.32"
 
 "@aws-amplify/auth@3.4.30":
   version "3.4.30"
@@ -57,6 +87,16 @@
     amazon-cognito-identity-js "4.6.0"
     crypto-js "^3.3.0"
 
+"@aws-amplify/auth@3.4.32":
+  version "3.4.32"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/auth/-/auth-3.4.32.tgz#10e066ff24c87cf1e10da9c8f4bbef4320ea1b68"
+  integrity sha512-bmVJWgVUXR1x0WcTLdhaGz/0lSS7Uz48m4EDG3Wp33YKVzDw7jgETv/cgSR79ycqkCKapaKLNzFzdLMM+nA0HA==
+  dependencies:
+    "@aws-amplify/cache" "4.0.0"
+    "@aws-amplify/core" "4.0.0"
+    amazon-cognito-identity-js "5.0.0"
+    crypto-js "^3.3.0"
+
 "@aws-amplify/cache@3.1.55":
   version "3.1.55"
   resolved "https://registry.yarnpkg.com/@aws-amplify/cache/-/cache-3.1.55.tgz#9fe1f2192e741bc27abeac29521881d9d060f8c0"
@@ -64,10 +104,30 @@
   dependencies:
     "@aws-amplify/core" "3.8.22"
 
+"@aws-amplify/cache@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/cache/-/cache-4.0.0.tgz#ed29566eb92c32e442b5e2c409ba081241f70fe3"
+  integrity sha512-DaKQopkF/zitMdnLEySTOE9Z/8PcJHVOH6MrVL59Boux26QSkxFlMeEtwJxiZrArobRW7XaV5U0LUFa2X+egBw==
+  dependencies:
+    "@aws-amplify/core" "4.0.0"
+
 "@aws-amplify/core@3.8.22":
   version "3.8.22"
   resolved "https://registry.yarnpkg.com/@aws-amplify/core/-/core-3.8.22.tgz#9a872772b6ac90f9474eadbcb178430739ee0bfb"
   integrity sha512-Plw0Gr6ik223bjBch/YicIUAhYTIEc8W3hx52u8jawpGMi1bcwmNAiuMMBvlSl50edbhmPgIw24GtyZNHLYDgQ==
+  dependencies:
+    "@aws-crypto/sha256-js" "1.0.0-alpha.0"
+    "@aws-sdk/client-cognito-identity" "3.6.1"
+    "@aws-sdk/credential-provider-cognito-identity" "3.6.1"
+    "@aws-sdk/types" "3.6.1"
+    "@aws-sdk/util-hex-encoding" "3.6.1"
+    universal-cookie "^4.0.4"
+    zen-observable-ts "0.8.19"
+
+"@aws-amplify/core@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/core/-/core-4.0.0.tgz#c57dc7ffe57f0f7538015676d638ec5eeda21f5a"
+  integrity sha512-8p3ArKETXI7uGEfn9x34jXdkvxTbiEatFsM3anmo4iKR37X9S1QfHVUbfaXrqeKD0b1XPvwulRLvan4yn8B6ng==
   dependencies:
     "@aws-crypto/sha256-js" "1.0.0-alpha.0"
     "@aws-sdk/client-cognito-identity" "3.6.1"
@@ -85,6 +145,22 @@
     "@aws-amplify/api" "3.2.30"
     "@aws-amplify/core" "3.8.22"
     "@aws-amplify/pubsub" "3.2.28"
+    idb "5.0.6"
+    immer "8.0.1"
+    ulid "2.3.0"
+    uuid "3.3.2"
+    zen-observable-ts "0.8.19"
+    zen-push "0.2.1"
+
+"@aws-amplify/datastore@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/datastore/-/datastore-3.0.0.tgz#34f072f9a2c4504cdf8a8bc3340fc5dae13c98e1"
+  integrity sha512-VHKmujKzDeUqU/dmqt8ESHFk8OYuymIZrKM1FfDb8/TsaWlW5N9fNw8TKz1kUf1XU9RnjDbLYrRygmRMqUD6dw==
+  dependencies:
+    "@aws-amplify/api" "3.3.1"
+    "@aws-amplify/auth" "3.4.32"
+    "@aws-amplify/core" "4.0.0"
+    "@aws-amplify/pubsub" "3.3.1"
     idb "5.0.6"
     immer "8.0.1"
     ulid "2.3.0"
@@ -124,6 +200,19 @@
     "@aws-amplify/auth" "3.4.30"
     "@aws-amplify/cache" "3.1.55"
     "@aws-amplify/core" "3.8.22"
+    graphql "14.0.0"
+    paho-mqtt "^1.1.0"
+    uuid "^3.2.1"
+    zen-observable-ts "0.8.19"
+
+"@aws-amplify/pubsub@3.3.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@aws-amplify/pubsub/-/pubsub-3.3.1.tgz#a8601dbab158c82942460746cc510ce9e5e6afde"
+  integrity sha512-lnx1TThblIg6jUW4gYbU8UQ6EVUzmvDircPtP213cBOTaGSMjKLMv243TcFKmEjYz3NsthvPOeE1d+yrdD8Q8g==
+  dependencies:
+    "@aws-amplify/auth" "3.4.32"
+    "@aws-amplify/cache" "4.0.0"
+    "@aws-amplify/core" "4.0.0"
     graphql "14.0.0"
     paho-mqtt "^1.1.0"
     uuid "^3.2.1"
@@ -3852,6 +3941,17 @@ amazon-cognito-identity-js@4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/amazon-cognito-identity-js/-/amazon-cognito-identity-js-4.6.0.tgz#311fe17b8a3ff65f119bca1cbdef7036e147076f"
   integrity sha512-D62rs0mcfA4APccAAsliWh1beOU7MBu/xj21W0kSOsjdc9diujgLHwHiHN6z91HSmJvztf69PUq4w4KuVKEjCA==
+  dependencies:
+    buffer "4.9.2"
+    crypto-js "^3.3.0"
+    fast-base64-decode "^1.0.0"
+    isomorphic-unfetch "^3.0.0"
+    js-cookie "^2.2.1"
+
+amazon-cognito-identity-js@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/amazon-cognito-identity-js/-/amazon-cognito-identity-js-5.0.0.tgz#53b4675035ff198d85b257e425259ba59eb0c766"
+  integrity sha512-Wv6vDgLAeioUDC07ApfNk9Bi8aW0peNArkLElyIWME6qQne0EuEFkmGklx0P9OeUlRLTpVSvXQryMVUyd9e2SQ==
   dependencies:
     buffer "4.9.2"
     crypto-js "^3.3.0"


### PR DESCRIPTION
# What does this PR do?

This PR adds `amplify datastore` https://docs.amplify.aws/lib/datastore/getting-started/q/platform/js#code-generation-platform-integration to automatically sync data between local state(indexeddb) and app sync.

example
```javascript
import { DataStore } from '@aws-amplify/datastore';
import { Moment } from './models';
...
await DataStore.save(
    new Moment({
		"createdAt": "1970-01-01T12:30:23.999Z",
		"title": "Lorem ipsum dolor sit amet",
		"contentType": ContentType.image,
		"content": "Lorem ipsum dolor sit amet",
		"asset": /* Provide a S3Object instance here */,
		"tags": [],
		"deleted": true,
		"sharedUsers": [],
		"comments": [],
		"reflexion": []
	})
);
```